### PR TITLE
Route

### DIFF
--- a/index.js
+++ b/index.js
@@ -122,7 +122,7 @@ module.exports = (attachToElement, sbot, opts = {}) => {
   return {
     goToGame: (gameId) => {
       var gameRoute = `/games/${btoa(gameId)}`;
-    //  m.route.set(gameRoute);
+      m.route.set(gameRoute);
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -118,4 +118,13 @@ module.exports = (attachToElement, sbot, opts = {}) => {
 
     appRouter(bodyDiv, gameCtrl);
   });
+
+  return {
+    goToGame: (gameId) => {
+      var gameRoute = `/games/${btoa(gameId)}`;
+    //  m.route.set(gameRoute);
+    }
+  }
+
+
 }

--- a/inject.js
+++ b/inject.js
@@ -47,9 +47,10 @@ exports.create = function(api) {
 
   function chessShow(location) {
     const rootEl = ChessContainer(location);
+    const gameId = location.key;
 
     onceTrue(api.sbot.obs.connection, (sbot) => {
-      index(rootEl, sbot, { initialView: `/games/${btoa(location.game)}` });
+      index(rootEl, sbot, { initialView: `/games/${btoa(gameId)}` });
     });
 
     return rootEl
@@ -87,4 +88,3 @@ function isChessMsg (loc) {
 function getRoot (msg) {
   return get(msg, ['value', 'content', 'root'], msg.key)
 }
-


### PR DESCRIPTION
Counter nerd snipe!

I added a couple of commits to your pull request to only have one instance of the chess app open at a time, and then reroute within `ssb-chess` if the user clicks a game link / open up at the appropriate route if it's the first time you've opened the chess tab.

I've encountered an error with hypertabs. Any idea what might be going on?

It seems to work under the following conditions:

* First time you've opened the chess app (via a link or via the 'chess' option in the menu at the top right.)
* You're already on the chess app and you go to another tab and click 'chess' again, it takes you back to the app.
* You click a chess game link, go to another tab, then click the game link again (takes you to the game.)
* You close the chess tab, and re-open it via the chess menu item or a game link.

Under the following conditions:

* You've followed a link to a chess game, the tab is open, then you click 'chess' via the menu at the top right.
* You're already on the chess app (the tab is open), then you follow a game link from a thread.

You get the following error:

```
TypeError: Cannot read property 'dataset' of null
    at setVisible (/home/happy0/projects/patchbay/node_modules/hypertabs/lib/util.js:43:32)
    at /home/happy0/projects/patchbay/node_modules/hypertabs/index.js:84:22
    at HTMLCollection.forEach (<anonymous>)
    at HTMLDivElement.d.select (/home/happy0/projects/patchbay/node_modules/hypertabs/index.js:83:18)
    at api.router.async.normalise (/home/happy0/projects/patchbay/app/sync/goTo.js:39:14)
    at Object.normalise (/home/happy0/projects/patchbay/router/async/normalise.js:16:7)
    at Object.normalise (/home/happy0/projects/patchbay/node_modules/depject/apply.js:18:30)
    at Object.goTo (/home/happy0/projects/patchbay/app/sync/goTo.js:34:22)
    at Object.goTo (/home/happy0/projects/patchbay/node_modules/depject/apply.js:18:30)
    at Array.api.history.obs.location.loc (/home/happy0/projects/patchbay/app/html/app.js:31:52)
    at ProtoComputed.broadcast (/home/happy0/projects/patchbay/node_modules/mutant/computed.js:208:19)
    at ProtoComputed.updateNow (/home/happy0/projects/patchbay/node_modules/mutant/computed.js:189:12)
    at ProtoComputed.onUpdate (/home/happy0/projects/patchbay/node_modules/mutant/computed.js:175:12)
    at broadcast (/home/happy0/projects/patchbay/node_modules/mutant/lib/lazy-watcher.js:111:27)
    at Object.broadcast (/home/happy0/projects/patchbay/node_modules/mutant/lib/lazy-watcher.js:24:9)
    at Function.Array.observable.push (/home/happy0/projects/patchbay/node_modules/mutant/array.js:50:12)
TypeError: Cannot read property 'title' of null
    at getTitle (/home/happy0/projects/patchbay/node_modules/hypertabs/tabs.js:100:16)
    at MutationObserver.observe.attributes (/home/happy0/projects/patchbay/node_modules/hypertabs/tabs.js:105:26)
```